### PR TITLE
Unit tests for logging in and out

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "trebol-ng",
-  "version": "1.1.37",
+  "version": "1.1.39",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trebol-ng",
-  "version": "1.1.38",
+  "version": "1.1.39",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -29,10 +29,6 @@ export class AppService
     this.fetchLoggedInState().subscribe();
   }
 
-  public get isLoggedIn(): boolean {
-    return (this.isLoggedInChangesSource as BehaviorSubject<boolean>)?.getValue();
-  }
-
   ngOnDestroy(): void {
     this.isLoggedInChangesSource.complete();
     this.isValidatingSessionSource.complete();
@@ -50,8 +46,12 @@ export class AppService
     );
   }
 
+  public isLoggedIn(): boolean {
+    return (this.isLoggedInChangesSource as BehaviorSubject<boolean>)?.getValue();
+  }
+
   public isUserLoggedIn(): Observable<boolean> {
-    const isCurrentlyLoggedIn = this.isLoggedIn;
+    const isCurrentlyLoggedIn = this.isLoggedIn();
     if (isCurrentlyLoggedIn === null) {
       return this.fetchLoggedInState();
     } else {
@@ -74,7 +74,7 @@ export class AppService
   }
 
   public login(credentials: Login): Observable<boolean> {
-    if (this.isLoggedIn) {
+    if (this.isLoggedIn()) {
       return of(true);
     } else {
       return this.authService.login(credentials).pipe(
@@ -99,7 +99,7 @@ export class AppService
   }
 
   public getAuthorizedAccess(): Observable<AuthorizedAccess> {
-    return this.isLoggedIn ? this.authService.getAuthorizedAccess() : of(null);
+    return this.isLoggedIn() ? this.authService.getAuthorizedAccess() : of(null);
   }
 
   public getUserProfile(): Observable<Person> {

--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -50,15 +50,6 @@ export class AppService
     return (this.isLoggedInChangesSource as BehaviorSubject<boolean>)?.getValue();
   }
 
-  public isUserLoggedIn(): Observable<boolean> {
-    const isCurrentlyLoggedIn = this.isLoggedIn();
-    if (isCurrentlyLoggedIn === null) {
-      return this.fetchLoggedInState();
-    } else {
-      return of(isCurrentlyLoggedIn);
-    }
-  }
-
   public guestLogin(personDetails: Person): Observable<boolean> {
     return this.authService.guestLogin(personDetails);
   }

--- a/src/app/management/management-routing.guard.ts
+++ b/src/app/management/management-routing.guard.ts
@@ -26,14 +26,8 @@ export class ManagementRoutingGuard
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
   ): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
-    return this.appService.isUserLoggedIn().pipe(
-      map(
-        r => {
-          if (!r) { return this.router.parseUrl('/'); }
-          return r;
-        }
-      )
-    );
+    const loggedIn = this.appService.isLoggedIn();
+    return loggedIn ? true : this.router.parseUrl('/');
   }
 
   canActivateChild(

--- a/src/app/shared/edit-profile-form-dialog/edit-profile-form.service.spec.ts
+++ b/src/app/shared/edit-profile-form-dialog/edit-profile-form.service.spec.ts
@@ -15,7 +15,6 @@ describe('EditProfileFormService', () => {
 
   beforeEach(() => {
     appService = {
-      isUserLoggedIn() { return of(true); },
       getUserProfile() { return of(new Person()); },
       updateUserProfile(p) { return of(true); }
     };

--- a/src/app/store/dialogs/login-form/store-login-form-dialog.component.spec.ts
+++ b/src/app/store/dialogs/login-form/store-login-form-dialog.component.spec.ts
@@ -62,4 +62,11 @@ describe('StoreLoginFormDialogComponent', () => {
     component.onSubmit();
     expect(appService.login).not.toHaveBeenCalled();
   });
+
+  it('should submit correct form', () => {
+    component.username.setValue('test');
+    component.password.setValue('pass');
+    component.onSubmit();
+    expect(appService.login).toHaveBeenCalled();
+  });
 });

--- a/src/app/store/dialogs/login-form/store-login-form-dialog.component.spec.ts
+++ b/src/app/store/dialogs/login-form/store-login-form-dialog.component.spec.ts
@@ -19,13 +19,18 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 describe('StoreLoginFormDialogComponent', () => {
   let component: StoreLoginFormDialogComponent;
   let fixture: ComponentFixture<StoreLoginFormDialogComponent>;
+  let dialog: Partial<MatDialogRef<StoreLoginFormDialogComponent>>;
   let appService: Partial<AppService>;
 
   beforeEach(async(() => {
+    dialog = {
+      close() {}
+    };
     appService = {
       login() { return of(true); }
     };
     spyOn(appService, 'login').and.callThrough();
+    spyOn(dialog, 'close');
 
     TestBed.configureTestingModule({
       imports: [
@@ -41,7 +46,7 @@ describe('StoreLoginFormDialogComponent', () => {
       ],
       declarations: [ StoreLoginFormDialogComponent ],
       providers: [
-        { provide: MatDialogRef, useValue: {} },
+        { provide: MatDialogRef, useValue: dialog },
         { provide: AppService, useValue: appService }
       ]
     })
@@ -68,5 +73,10 @@ describe('StoreLoginFormDialogComponent', () => {
     component.password.setValue('pass');
     component.onSubmit();
     expect(appService.login).toHaveBeenCalled();
+  });
+
+  it('should close upon cancellation', () => {
+    component.onCancel();
+    expect(dialog.close).toHaveBeenCalled();
   });
 });

--- a/src/app/store/dialogs/login-form/store-login-form-dialog.component.spec.ts
+++ b/src/app/store/dialogs/login-form/store-login-form-dialog.component.spec.ts
@@ -44,7 +44,6 @@ describe('StoreLoginFormDialogComponent', () => {
         FormsModule,
         MatInputModule,
         MatFormFieldModule,
-        MatDialogModule,
         RouterTestingModule
       ],
       declarations: [ StoreLoginFormDialogComponent ],

--- a/src/app/store/dialogs/login-form/store-login-form-dialog.component.spec.ts
+++ b/src/app/store/dialogs/login-form/store-login-form-dialog.component.spec.ts
@@ -65,6 +65,11 @@ describe('StoreLoginFormDialogComponent', () => {
 
   it('should not submit incomplete form', () => {
     component.onSubmit();
+    component.username.setValue('test');
+    component.onSubmit();
+    component.formGroup.reset();
+    component.password.setValue('test');
+    component.onSubmit();
     expect(appService.login).not.toHaveBeenCalled();
   });
 

--- a/src/app/store/dialogs/login-form/store-login-form-dialog.component.spec.ts
+++ b/src/app/store/dialogs/login-form/store-login-form-dialog.component.spec.ts
@@ -60,6 +60,6 @@ describe('StoreLoginFormDialogComponent', () => {
 
   it('should not submit incomplete form', () => {
     component.onSubmit();
-    expect(appService.login).toHaveBeenCalledTimes(0);
+    expect(appService.login).not.toHaveBeenCalled();
   });
 });

--- a/src/app/store/dialogs/login-form/store-login-form-dialog.component.spec.ts
+++ b/src/app/store/dialogs/login-form/store-login-form-dialog.component.spec.ts
@@ -25,6 +25,7 @@ describe('StoreLoginFormDialogComponent', () => {
     appService = {
       login() { return of(true); }
     };
+    spyOn(appService, 'login').and.callThrough();
 
     TestBed.configureTestingModule({
       imports: [
@@ -55,5 +56,10 @@ describe('StoreLoginFormDialogComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should not submit incomplete form', () => {
+    component.onSubmit();
+    expect(appService.login).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/app/store/dialogs/login-form/store-login-form-dialog.component.spec.ts
+++ b/src/app/store/dialogs/login-form/store-login-form-dialog.component.spec.ts
@@ -14,13 +14,14 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatSnackBarModule, MatSnackBar } from '@angular/material/snack-bar';
 
 describe('StoreLoginFormDialogComponent', () => {
   let component: StoreLoginFormDialogComponent;
   let fixture: ComponentFixture<StoreLoginFormDialogComponent>;
   let dialog: Partial<MatDialogRef<StoreLoginFormDialogComponent>>;
   let appService: Partial<AppService>;
+  let snackBar: Partial<MatSnackBar>;
 
   beforeEach(async(() => {
     dialog = {
@@ -28,6 +29,9 @@ describe('StoreLoginFormDialogComponent', () => {
     };
     appService = {
       login() { return of(true); }
+    };
+    snackBar = {
+      open() { return undefined; }
     };
     spyOn(appService, 'login').and.callThrough();
     spyOn(dialog, 'close');
@@ -41,13 +45,13 @@ describe('StoreLoginFormDialogComponent', () => {
         MatInputModule,
         MatFormFieldModule,
         MatDialogModule,
-        MatSnackBarModule,
         RouterTestingModule
       ],
       declarations: [ StoreLoginFormDialogComponent ],
       providers: [
         { provide: MatDialogRef, useValue: dialog },
-        { provide: AppService, useValue: appService }
+        { provide: AppService, useValue: appService },
+        { provide: MatSnackBar, useValue: snackBar }
       ]
     })
     .compileComponents();

--- a/src/app/store/dialogs/login-form/store-login-form-dialog.component.ts
+++ b/src/app/store/dialogs/login-form/store-login-form-dialog.component.ts
@@ -52,28 +52,30 @@ export class StoreLoginFormDialogComponent {
   public hidePassword(): void { this.hidePasswordSource.next(true); }
 
   public onSubmit(): void {
-    this.loggingInSource.next(true);
+    if (this.formGroup.valid) {
+      this.loggingInSource.next(true);
 
-    const details: Login = {
-      name: this.username.value,
-      password: this.password.value
-    };
+      const details: Login = {
+        name: this.username.value,
+        password: this.password.value
+      };
 
-    this.appService.login(details).subscribe(
-      () => {
-        this.dialog.close();
-        this.snackBarService.open(LOGIN_SUCCESS_MESSAGE, 'OK');
-      },
-      error => {
-        if (error.status === 403) {
-          this.loggingInSource.next(false);
-          this.snackBarService.open(LOGIN_ERROR_MESSAGE, 'OK');
-        } else {
-          this.loggingInSource.next(false);
-          this.snackBarService.open(UNKNOWN_ERROR_MESSAGE, 'OK');
+      this.appService.login(details).subscribe(
+        () => {
+          this.dialog.close();
+          this.snackBarService.open(LOGIN_SUCCESS_MESSAGE, 'OK');
+        },
+        error => {
+          if (error.status === 403) {
+            this.loggingInSource.next(false);
+            this.snackBarService.open(LOGIN_ERROR_MESSAGE, 'OK');
+          } else {
+            this.loggingInSource.next(false);
+            this.snackBarService.open(UNKNOWN_ERROR_MESSAGE, 'OK');
+          }
         }
-      }
-    );
+      );
+    }
   }
 
   public onCancel(): void {

--- a/src/app/store/header/store-header.component.html
+++ b/src/app/store/header/store-header.component.html
@@ -18,7 +18,7 @@
       <a mat-button title="Ir al Carrito" [routerLink]="['/store', 'cart']">
         <mat-icon>shopping_cart</mat-icon>
         <span class="cart-summary">
-          <span>{{ cartItemCountLabel$$ | async }}</span>
+          <span>{{ cartItemCountLabel$ | async }}</span>
           <span>${{ cartSubtotalValue$ | async }}</span>
         </span>
       </a>

--- a/src/app/store/header/store-header.component.spec.ts
+++ b/src/app/store/header/store-header.component.spec.ts
@@ -5,7 +5,7 @@
 
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { of } from 'rxjs';
+import { of, empty } from 'rxjs';
 import { AppService } from 'src/app/app.service';
 import { StoreService } from '../store.service';
 import { StoreHeaderComponent } from './store-header.component';
@@ -14,7 +14,9 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatIconModule } from '@angular/material/icon';
 import { CommonModule } from '@angular/common';
-import { MatDialogModule } from '@angular/material/dialog';
+import { MatDialogModule, MatDialogRef, MatDialog } from '@angular/material/dialog';
+import { StoreCompanyDetailsDialogComponent } from '../dialogs/company-details/store-company-details-dialog.component';
+import { StoreLoginFormDialogComponent } from '../dialogs/login-form/store-login-form-dialog.component';
 
 describe('StoreHeaderComponent', () => {
   let component: StoreHeaderComponent;
@@ -22,6 +24,7 @@ describe('StoreHeaderComponent', () => {
   let storeService: Partial<StoreService>;
   let appService: Partial<AppService>;
   let snackBarService: Partial<MatSnackBar>;
+  let dialogService: any;
 
   beforeEach(async(() => {
     storeService = {
@@ -35,6 +38,10 @@ describe('StoreHeaderComponent', () => {
       closeCurrentSession() {},
       getUserProfile() { return of(null); }
     };
+    dialogService = {
+      open() { return { afterClosed: () => empty() } }
+    };
+    spyOn(dialogService, 'open').and.callThrough();
 
     TestBed.configureTestingModule({
       imports: [
@@ -49,7 +56,8 @@ describe('StoreHeaderComponent', () => {
       providers: [
         { provide: StoreService, useValue: storeService },
         { provide: AppService, useValue: appService },
-        { provide: MatSnackBar, useValue: snackBarService }
+        { provide: MatSnackBar, useValue: snackBarService },
+        { provide: MatDialog, useValue: dialogService }
       ]
     })
     .compileComponents();
@@ -63,5 +71,10 @@ describe('StoreHeaderComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should prompt a login dialog', () => {
+    component.onClickLogIn();
+    expect(dialogService.open).toHaveBeenCalled();
   });
 });

--- a/src/app/store/header/store-header.component.spec.ts
+++ b/src/app/store/header/store-header.component.spec.ts
@@ -7,16 +7,21 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { of } from 'rxjs';
 import { AppService } from 'src/app/app.service';
-import { Person } from 'src/app/data/models/entities/Person';
-import { SharedModule } from 'src/app/shared/shared.module';
 import { StoreService } from '../store.service';
 import { StoreHeaderComponent } from './store-header.component';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatButtonModule } from '@angular/material/button';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatIconModule } from '@angular/material/icon';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule } from '@angular/material/dialog';
 
 describe('StoreHeaderComponent', () => {
   let component: StoreHeaderComponent;
   let fixture: ComponentFixture<StoreHeaderComponent>;
   let storeService: Partial<StoreService>;
   let appService: Partial<AppService>;
+  let snackBarService: Partial<MatSnackBar>;
 
   beforeEach(async(() => {
     storeService = {
@@ -33,13 +38,18 @@ describe('StoreHeaderComponent', () => {
 
     TestBed.configureTestingModule({
       imports: [
+        CommonModule,
         RouterTestingModule,
-        SharedModule
+        MatButtonModule,
+        MatMenuModule,
+        MatIconModule,
+        MatDialogModule
       ],
       declarations: [ StoreHeaderComponent ],
       providers: [
         { provide: StoreService, useValue: storeService },
-        { provide: AppService, useValue: appService }
+        { provide: AppService, useValue: appService },
+        { provide: MatSnackBar, useValue: snackBarService }
       ]
     })
     .compileComponents();

--- a/src/app/store/header/store-header.component.spec.ts
+++ b/src/app/store/header/store-header.component.spec.ts
@@ -34,7 +34,6 @@ describe('StoreHeaderComponent', () => {
     };
     appService = {
       isLoggedInChanges$: of(false),
-      isUserLoggedIn() { return of(false); },
       closeCurrentSession() {},
       getUserProfile() { return of(null); }
     };
@@ -83,7 +82,7 @@ describe('StoreHeaderComponent', () => {
     expect(dialogService.open).not.toHaveBeenCalled();
 
     appService.isLoggedInChanges$ = of(true);
-    appService.isUserLoggedIn = (() => { return of(true); });
+    appService.isLoggedIn = (() => { return true; });
     component.onClickLogout();
     expect(dialogService.open).toHaveBeenCalled();
   });

--- a/src/app/store/header/store-header.component.spec.ts
+++ b/src/app/store/header/store-header.component.spec.ts
@@ -33,6 +33,7 @@ describe('StoreHeaderComponent', () => {
       cartSubtotalValue$: of(0)
     };
     appService = {
+      isLoggedIn() { return false },
       isLoggedInChanges$: of(false),
       closeCurrentSession() {},
       getUserProfile() { return of(null); }

--- a/src/app/store/header/store-header.component.spec.ts
+++ b/src/app/store/header/store-header.component.spec.ts
@@ -77,4 +77,14 @@ describe('StoreHeaderComponent', () => {
     component.onClickLogIn();
     expect(dialogService.open).toHaveBeenCalled();
   });
+
+  it('should prompt a logout confirmation, only when logged in', () => {
+    component.onClickLogout();
+    expect(dialogService.open).not.toHaveBeenCalled();
+
+    appService.isLoggedInChanges$ = of(true);
+    appService.isUserLoggedIn = (() => { return of(true); });
+    component.onClickLogout();
+    expect(dialogService.open).toHaveBeenCalled();
+  });
 });

--- a/src/app/store/header/store-header.component.ts
+++ b/src/app/store/header/store-header.component.ts
@@ -144,7 +144,7 @@ export class StoreHeaderComponent
   }
 
   public onClickLogout(): void {
-    if (this.appService.isLoggedIn) {
+    if (this.appService.isLoggedIn()) {
       this.promptLogoutConfirmation().subscribe(
         confirmed => {
           if (confirmed) {

--- a/src/app/store/header/store-header.component.ts
+++ b/src/app/store/header/store-header.component.ts
@@ -144,14 +144,16 @@ export class StoreHeaderComponent
   }
 
   public onClickLogout(): void {
-    this.promptLogoutConfirmation().subscribe(
-      confirmed => {
-        if (confirmed) {
-          this.snackBarService.open(LOGOUT_MESSAGE, 'OK');
-          this.appService.closeCurrentSession();
+    if (this.appService.isLoggedIn) {
+      this.promptLogoutConfirmation().subscribe(
+        confirmed => {
+          if (confirmed) {
+            this.snackBarService.open(LOGOUT_MESSAGE, 'OK');
+            this.appService.closeCurrentSession();
+          }
         }
-      }
-    );
+      );
+    }
   }
 
 }

--- a/src/app/store/routes/cart-review/store-cart-review.component.spec.ts
+++ b/src/app/store/routes/cart-review/store-cart-review.component.spec.ts
@@ -30,7 +30,7 @@ describe('StoreCartReviewComponent', () => {
       removeProductFromCart(i) {}
     };
     appService = {
-      isLoggedIn: false
+      isLoggedIn() { return false; }
     };
 
     TestBed.configureTestingModule({

--- a/src/app/store/routes/cart-review/store-cart-review.component.ts
+++ b/src/app/store/routes/cart-review/store-cart-review.component.ts
@@ -129,12 +129,12 @@ export class StoreCartReviewComponent
   }
 
   public onClickAccept(): void {
-    if (this.appService.isLoggedIn) {
+    if (this.appService.isLoggedIn()) {
       this.openPaymentRedirectPrompt();
     } else {
       this.promptUserLoginChoices().subscribe(
         () => {
-          if (this.appService.isLoggedIn) {
+          if (this.appService.isLoggedIn()) {
             this.openPaymentRedirectPrompt();
           }
         }


### PR DESCRIPTION
These tests cover the AppService logic, the calls from the LoginFormDialogComponent, and the dialog prompt from the StoreHeaderComponent. It also covers the logout prompt call from the StoreHeaderComponent.

*It does not cover actually logging out* since it requires to 'say no' in the ConfirmationDialogComponent from the `/src/app/shared` module, which is to be done later on.

In the process, I removed some redundantcy from the AppService as well.